### PR TITLE
run script without deploying

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,45 +15,57 @@ forge install memester-xyz/solenv
 Firstly, it's very important that you do not commit your `.env` file. It should go without saying but make sure to add it to your `.gitignore` file! This repo has committed the `.env` and `.env.test` files only for examples and tests.
 
 1. Add this import to your script or test:
+
 ```solidity
 import {Solenv} from "solenv/Solenv.sol";
 ```
 
-2. Call `.config()` somewhere. It defaults to using `.env` in your project root, but you can pass another string as a parameter to load another file in instead.
+2. Inherit Solenv
+
+```solidity
+contract SolenvScript is Solenv {
+    // Contract contents...
+}
+```
+
+3. Call `.config()` somewhere. It defaults to using `.env` in your project root, but you can pass another string as a parameter to load another file in instead.
+
 ```solidity
 // Inside a test
 function setUp() public {
-    Solenv.config();
+    config();
 }
 
 // Inside a script, load a file with a different name
 function run() public {
-    Solenv.config(".env.prod");
+    config(".env.prod");
 
     // Continue with your script...
 }
 ```
 
-3. You can then use the [standard "env" cheatcodes](https://book.getfoundry.sh/cheatcodes/external.html) in order to read your variables. e.g. `envString`, `envUint`, `envBool`, etc.
+4. You can then use the [standard "env" cheatcodes](https://book.getfoundry.sh/cheatcodes/external.html) in order to read your variables. e.g. `envString`, `envUint`, `envBool`, etc.
+
 ```solidity
 string memory apiKey = vm.envString("API_KEY");
 uint256 retries = vm.envUint("RETRIES");
 bool ouputLogs = vm.envBool("OUTPUT_LOGS");
 ```
 
-4. You must enable [ffi](https://book.getfoundry.sh/cheatcodes/ffi.html) in order to use the library. You can either pass the `--ffi` flag to any forge commands you run (e.g. `forge script Script --ffi`), or you can add `ffi = true` to your `foundry.toml` file.
+5. You must enable [ffi](https://book.getfoundry.sh/cheatcodes/ffi.html) in order to use the library. You can either pass the `--ffi` flag to any forge commands you run (e.g. `forge script Script --ffi`), or you can add `ffi = true` to your `foundry.toml` file.
 
 ### Notes
 
- - Comments start with `#` and must be on a newline
- - If you set a key twice, the last value in the file is used
- - It assumes you are running on a UNIX based machine with `sh`, `cast` and `xxd` installed.
+- Comments start with `#` and must be on a newline
+- If you set a key twice, the last value in the file is used
+- It assumes you are running on a UNIX based machine with `sh`, `cast` and `xxd` installed.
 
 ## Example
 
 We have example usage for both [tests](./test/Solenv.t.sol) and [scripts](./script/Solenv.s.sol).
 
 To see the script in action, you can run:
+
 ```
 forge script SolenvScript
 ```

--- a/script/Solenv.s.sol
+++ b/script/Solenv.s.sol
@@ -5,9 +5,9 @@ import "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";
 import {Solenv} from "src/Solenv.sol";
 
-contract SolenvScript is Script {
+contract SolenvScript is Script, Solenv {
     function setUp() public {
-        Solenv.config();
+        config();
     }
 
     function run() public {

--- a/src/Solenv.sol
+++ b/src/Solenv.sol
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
+import "forge-std/Script.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {strings} from "solidity-stringutils/strings.sol";
 
-library Solenv {
+contract Solenv is Script {
     using strings for *;
-
-    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
 
     function config(string memory filename) public {
         string[] memory inputs = new string[](3);

--- a/test/Solenv.t.sol
+++ b/test/Solenv.t.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.13;
 import "forge-std/Test.sol";
 import {Solenv} from "src/Solenv.sol";
 
-contract SolenvTest is Test {
+contract SolenvTest is Test, Solenv {
     function setUp() public {}
 
     function testEnvLoad() public {
-        Solenv.config();
+        config();
 
         assertEq(vm.envString("WHY_USE_THIS_KEY"), "because we can can can");
         assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"), "omgnoway");
@@ -33,9 +33,9 @@ contract SolenvTest is Test {
     }
 }
 
-contract SolenvInSetupTest is Test {
+contract SolenvInSetupTest is Test, Solenv {
     function setUp() public {
-        Solenv.config();
+        config();
     }
 
     function testEnvLoad() public {


### PR DESCRIPTION
This commit allows the Solenv contract to be used without the script deploying a Solenv instance on chain, this is useful for mainnet deployments where you do not want to pay gas for a helper script.