### PR TITLE
Update profile notation

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = 'src'
 out = 'out'
 libs = ['lib']


### PR DESCRIPTION
Using `solenv` in my project, with the latest `forge` version `forge 0.2.0 (3c49efe 2022-07-14T00:05:10.018576Z)` I get the warning that `default` was deprecated in favor of `profile.default`