### PR TITLE
feat: enable merging .env (no-clobber mode)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/foundry-rs/forge-std
 [submodule "lib/solidity-stringutils"]
 	path = lib/solidity-stringutils
-	url = https://github.com/Arachnid/solidity-stringutils
+	url = https://github.com/proximacapital/solidity-stringutils

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,5 +3,6 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 ffi = true
+verbosity = 3
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/Solenv.sol
+++ b/src/Solenv.sol
@@ -24,7 +24,7 @@ library Solenv {
     }
 
     // todo: check if we can support setting delimiters
-    function _config(string memory filename, bool overwrite) private {
+    function _config(string memory filename, bool overwrite) private returns (bool success) {
         string[] memory inputs = new string[](3);
         inputs[0] = "sh";
         inputs[1] = "-c";
@@ -33,6 +33,14 @@ library Solenv {
         );
 
         bytes memory res = vm.ffi(inputs);
+        try vm.ffi(inputs) returns (bytes memory rRes) {
+            res = rRes;
+        } catch {
+            // failed to load the env from file, we assume if the script needs
+            // the env vars they will try to read them and subsequently error.
+            // ergo, it is preferable to just return gracefully here
+            return false;
+        }
 
         strings.slice memory data = abi.decode(res, (string)).toSlice();
 
@@ -60,21 +68,23 @@ library Solenv {
                 }
             }
         }
+
+        return true;
     }
 
-    function config(string memory filename, bool overwrite) internal {
-        _config(filename, overwrite);
+    function config(string memory filename, bool overwrite) internal returns (bool success) {
+        return _config(filename, overwrite);
     }
 
-    function config(string memory filename) internal {
-        config(filename, true);
+    function config(string memory filename) internal returns (bool success) {
+        return config(filename, true);
     }
 
-    function config(bool overwrite) internal {
-        config(DEFAULT_ENV_LOCATION, overwrite);
+    function config(bool overwrite) internal returns (bool success) {
+        return config(DEFAULT_ENV_LOCATION, overwrite);
     }
 
-    function config() internal {
-        config(DEFAULT_ENV_LOCATION);
+    function config() internal returns (bool success) {
+        return config(DEFAULT_ENV_LOCATION);
     }
 }

--- a/src/Solenv.sol
+++ b/src/Solenv.sol
@@ -4,12 +4,27 @@ pragma solidity ^0.8.13;
 import {Vm} from "forge-std/Vm.sol";
 import {strings} from "solidity-stringutils/strings.sol";
 
+string constant DEFAULT_ENV_LOCATION = ".env";
+
 library Solenv {
     using strings for *;
 
     Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
 
-    function config(string memory filename) internal {
+    function _envExists(string memory key) private returns (bool) {
+        try vm.envString(key) returns (string memory rEnv) {
+            if (keccak256(abi.encodePacked(rEnv)) == keccak256("")) {
+                return false;
+            } else {
+                return true;
+            }
+        } catch {
+            return false;
+        }
+    }
+
+    // todo: check if we can support setting delimiters
+    function _config(string memory filename, bool overwrite) private {
         string[] memory inputs = new string[](3);
         inputs[0] = "sh";
         inputs[1] = "-c";
@@ -32,13 +47,34 @@ library Solenv {
                 string memory key = line.split(keyDelim).toString();
                 // Ignore empty lines
                 if (bytes(key).length != 0) {
-                    vm.setEnv(key, line.toString());
+                    if (overwrite == true) {
+                        vm.setEnv(key, line.toString());
+                    } else {
+                        if (_envExists(key)) {
+                            // pre-existing found, do not overwrite
+                        } else {
+                            // pre-existing not found, insert
+                            vm.setEnv(key, line.toString());
+                        }
+                    }
                 }
             }
         }
     }
 
+    function config(string memory filename, bool overwrite) internal {
+        _config(filename, overwrite);
+    }
+
+    function config(string memory filename) internal {
+        config(filename, true);
+    }
+
+    function config(bool overwrite) internal {
+        config(DEFAULT_ENV_LOCATION, overwrite);
+    }
+
     function config() internal {
-        config(".env");
+        config(DEFAULT_ENV_LOCATION);
     }
 }

--- a/src/Solenv.sol
+++ b/src/Solenv.sol
@@ -29,7 +29,7 @@ library Solenv {
         inputs[0] = "sh";
         inputs[1] = "-c";
         inputs[2] = string(
-            bytes.concat('cast abi-encode "response(bytes)" $(xxd -p -c 0 ', bytes(filename), ")")
+            bytes.concat('cast abi-encode "response(bytes)" $(xxd -p -c 999999999 ', bytes(filename), ")")
         );
 
         bytes memory res = vm.ffi(inputs);

--- a/src/Solenv.sol
+++ b/src/Solenv.sol
@@ -24,7 +24,7 @@ library Solenv {
     }
 
     // todo: check if we can support setting delimiters
-    function _config(string memory filename, bool overwrite) private returns (bool success) {
+    function _config(string memory filename, bool overwrite) private {
         string[] memory inputs = new string[](3);
         inputs[0] = "sh";
         inputs[1] = "-c";
@@ -33,15 +33,6 @@ library Solenv {
         );
 
         bytes memory res = vm.ffi(inputs);
-        try vm.ffi(inputs) returns (bytes memory rRes) {
-            res = rRes;
-        } catch {
-            // failed to load the env from file, we assume if the script needs
-            // the env vars they will try to read them and subsequently error.
-            // ergo, it is preferable to just return gracefully here
-            return false;
-        }
-
         strings.slice memory data = abi.decode(res, (string)).toSlice();
 
         strings.slice memory lineDelim = "\n".toSlice();
@@ -68,23 +59,21 @@ library Solenv {
                 }
             }
         }
-
-        return true;
     }
 
-    function config(string memory filename, bool overwrite) internal returns (bool success) {
-        return _config(filename, overwrite);
+    function config(string memory filename, bool overwrite) internal {
+        _config(filename, overwrite);
     }
 
-    function config(string memory filename) internal returns (bool success) {
-        return config(filename, true);
+    function config(string memory filename) internal {
+        config(filename, true);
     }
 
-    function config(bool overwrite) internal returns (bool success) {
-        return config(DEFAULT_ENV_LOCATION, overwrite);
+    function config(bool overwrite) internal {
+        config(DEFAULT_ENV_LOCATION, overwrite);
     }
 
-    function config() internal returns (bool success) {
-        return config(DEFAULT_ENV_LOCATION);
+    function config() internal {
+        config(DEFAULT_ENV_LOCATION);
     }
 }

--- a/src/Solenv.sol
+++ b/src/Solenv.sol
@@ -14,7 +14,7 @@ library Solenv {
         inputs[0] = "sh";
         inputs[1] = "-c";
         inputs[2] = string(
-            bytes.concat('cast abi-encode "response(bytes)" $(xxd -p -c 1000000 ', bytes(filename), ")")
+            bytes.concat('cast abi-encode "response(bytes)" $(xxd -p -c 0 ', bytes(filename), ")")
         );
 
         bytes memory res = vm.ffi(inputs);

--- a/test/Solenv.t.sol
+++ b/test/Solenv.t.sol
@@ -4,54 +4,100 @@ pragma solidity ^0.8.13;
 import "forge-std/Test.sol";
 import {Solenv} from "src/Solenv.sol";
 
-contract SolenvTest is Test {
-    function setUp() public {}
+library SolenvHelper {
+    address constant private VM_ADDRESS =
+        address(bytes20(uint160(uint256(keccak256('hevm cheat code')))));
+    Vm constant private vm = Vm(VM_ADDRESS);
 
+    function resetEnv() internal {
+        vm.setEnv("WHY_USE_THIS_KEY",               "");
+        vm.setEnv("SOME_VERY_IMPORTANT_API_KEY",    "");
+        vm.setEnv("A_COMPLEX_ENV_VARIABLE",         "");
+        vm.setEnv("A_NUMBER",                       "");
+        vm.setEnv("A_TRUE_BOOL",                    "");
+        vm.setEnv("A_FALSE_BOOL",                   "");
+        vm.setEnv("A_FALSE_BOOL",                   "");
+        vm.setEnv("AN_ADDRESS",                     "");
+        vm.setEnv("A_BYTES_32",                     "");
+    }
+}
+
+contract SolenvTest is Test {
     function testEnvLoad() public {
+        // act
         Solenv.config();
 
-        assertEq(vm.envString("WHY_USE_THIS_KEY"), "because we can can can");
-        assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"), "omgnoway");
-        assertEq(vm.envString("A_COMPLEX_ENV_VARIABLE"), "y&2U9xiEINv!vM8Gez");
-
-        assertEq(vm.envUint("A_NUMBER"), 100);
-
-        assertEq(vm.envBool("A_TRUE_BOOL"), true);
-        assertEq(vm.envBool("A_FALSE_BOOL"), false);
-
-        assertEq(vm.envBool("A_FALSE_BOOL"), false);
-
+        // assert
+        assertEq(vm.envString("WHY_USE_THIS_KEY"),              "because we can can can");
+        assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"),   "omgnoway");
+        assertEq(vm.envString("A_COMPLEX_ENV_VARIABLE"),        "y&2U9xiEINv!vM8Gez");
+        assertEq(vm.envUint("A_NUMBER"),                        100);
+        assertEq(vm.envBool("A_TRUE_BOOL"),                     true);
+        assertEq(vm.envBool("A_FALSE_BOOL"),                    false);
+        assertEq(vm.envBool("A_FALSE_BOOL"),                    false);
         assertEq(vm.envAddress("AN_ADDRESS"), 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
-
         assertEq(vm.envBytes32("A_BYTES_32"), 0x0000000000000000000000000000000000000000000000000000000000000010);
+
+        // cleanup
+        SolenvHelper.resetEnv();
     }
 
     function testAnotherFileName() public {
         Solenv.config(".env.test");
 
         assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"), "adifferentone");
+
+        SolenvHelper.resetEnv();
+    }
+}
+
+contract SolenvMergeTest is Test {
+    function testEnvMerge() public {
+        // arrange
+        vm.setEnv("WHY_USE_THIS_KEY",   "different value");
+        vm.setEnv("A_NUMBER",           "1337");
+        vm.setEnv("A_TRUE_BOOL",        "false");
+        vm.setEnv("A_FALSE_BOOL",       "true");
+
+        // act
+        Solenv.config(false);
+
+        // assert
+        // from file
+        assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"),   "omgnoway");
+        assertEq(vm.envString("A_COMPLEX_ENV_VARIABLE"),        "y&2U9xiEINv!vM8Gez");
+        assertEq(vm.envAddress("AN_ADDRESS"), 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+        assertEq(vm.envBytes32("A_BYTES_32"), 0x0000000000000000000000000000000000000000000000000000000000000010);
+
+        // set manually
+        assertEq(vm.envString("WHY_USE_THIS_KEY"),  "different value");
+        assertEq(vm.envUint("A_NUMBER"),            1337);
+        assertEq(vm.envBool("A_TRUE_BOOL"),         false);
+        assertEq(vm.envBool("A_FALSE_BOOL"),        true);
+
+        // cleanup
+        SolenvHelper.resetEnv();
     }
 }
 
 contract SolenvInSetupTest is Test {
     function setUp() public {
+        // act
         Solenv.config();
     }
 
     function testEnvLoad() public {
-        assertEq(vm.envString("WHY_USE_THIS_KEY"), "because we can can can");
-        assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"), "omgnoway");
-        assertEq(vm.envString("A_COMPLEX_ENV_VARIABLE"), "y&2U9xiEINv!vM8Gez");
-
-        assertEq(vm.envUint("A_NUMBER"), 100);
-
-        assertEq(vm.envBool("A_TRUE_BOOL"), true);
-        assertEq(vm.envBool("A_FALSE_BOOL"), false);
-
-        assertEq(vm.envBool("A_FALSE_BOOL"), false);
-
+        // assert
+        assertEq(vm.envString("WHY_USE_THIS_KEY"),              "because we can can can");
+        assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"),   "omgnoway");
+        assertEq(vm.envString("A_COMPLEX_ENV_VARIABLE"),        "y&2U9xiEINv!vM8Gez");
+        assertEq(vm.envUint("A_NUMBER"),                        100);
+        assertEq(vm.envBool("A_TRUE_BOOL"),                     true);
+        assertEq(vm.envBool("A_FALSE_BOOL"),                    false);
+        assertEq(vm.envBool("A_FALSE_BOOL"),                    false);
         assertEq(vm.envAddress("AN_ADDRESS"), 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
-
         assertEq(vm.envBytes32("A_BYTES_32"), 0x0000000000000000000000000000000000000000000000000000000000000010);
+
+        SolenvHelper.resetEnv();
     }
 }

--- a/test/Solenv.t.sol
+++ b/test/Solenv.t.sol
@@ -23,7 +23,7 @@ library SolenvHelper {
 }
 
 contract SolenvTest is Test {
-    function testEnvLoad() public {
+    function testEnv() public {
         // act
         Solenv.config();
 
@@ -42,7 +42,7 @@ contract SolenvTest is Test {
         SolenvHelper.resetEnv();
     }
 
-    function testAnotherFileName() public {
+    function testEnv_AnotherFilename() public {
         Solenv.config(".env.test");
 
         assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"), "adifferentone");
@@ -52,7 +52,7 @@ contract SolenvTest is Test {
 }
 
 contract SolenvMergeTest is Test {
-    function testEnvMerge() public {
+    function testEnv_Merge() public {
         // arrange
         vm.setEnv("WHY_USE_THIS_KEY",   "different value");
         vm.setEnv("A_NUMBER",           "1337");
@@ -86,7 +86,7 @@ contract SolenvInSetupTest is Test {
         Solenv.config();
     }
 
-    function testEnvLoad() public {
+    function testEnv_InSetup() public {
         // assert
         assertEq(vm.envString("WHY_USE_THIS_KEY"),              "because we can can can");
         assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"),   "omgnoway");

--- a/test/Solenv.t.sol
+++ b/test/Solenv.t.sol
@@ -5,10 +5,8 @@ import "forge-std/Test.sol";
 import {Solenv} from "src/Solenv.sol";
 
 contract SolenvTest is Test {
-    bool private _success;
-
     function setUp() external {
-        _success = Solenv.config();
+        Solenv.config();
     }
 
     function _assertDefault() private {
@@ -51,14 +49,12 @@ contract SolenvTest is Test {
         _resetEnv();
 
         // LOAD DEFAULT CONFIG
-        bool success = Solenv.config();
-        assertEq(success, true);
+        Solenv.config();
         _assertDefault();
         _resetEnv();
 
         // TEST ANOTHER FILENAME
-        success = Solenv.config(".env.test");
-        assertEq(success, true);
+        Solenv.config(".env.test");
         assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"), "adifferentone");
         _resetEnv();
 
@@ -69,11 +65,11 @@ contract SolenvTest is Test {
         vm.setEnv("A_TRUE_BOOL",        "false");
         vm.setEnv("A_FALSE_BOOL",       "true");
 
-        success = Solenv.config(".env", false);
+        // act
+        Solenv.config(".env", false);
 
         // assert
         // from file
-        assertEq(success, true);
         assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"),   "omgnoway");
         assertEq(vm.envString("A_COMPLEX_ENV_VARIABLE"),        "y&2U9xiEINv!vM8Gez");
         assertEq(vm.envAddress("AN_ADDRESS"), 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);

--- a/test/Solenv.t.sol
+++ b/test/Solenv.t.sol
@@ -25,9 +25,10 @@ library SolenvHelper {
 contract SolenvTest is Test {
     function testEnv() public {
         // act
-        Solenv.config();
+        bool success = Solenv.config();
 
         // assert
+        assertEq(success, true);
         assertEq(vm.envString("WHY_USE_THIS_KEY"),              "because we can can can");
         assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"),   "omgnoway");
         assertEq(vm.envString("A_COMPLEX_ENV_VARIABLE"),        "y&2U9xiEINv!vM8Gez");
@@ -43,8 +44,9 @@ contract SolenvTest is Test {
     }
 
     function testEnv_AnotherFilename() public {
-        Solenv.config(".env.test");
+        bool success = Solenv.config(".env.test");
 
+        assertEq(success, true);
         assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"), "adifferentone");
 
         SolenvHelper.resetEnv();
@@ -60,10 +62,11 @@ contract SolenvMergeTest is Test {
         vm.setEnv("A_FALSE_BOOL",       "true");
 
         // act
-        Solenv.config(false);
+        bool success = Solenv.config(".env.test");
 
         // assert
         // from file
+        assertEq(success, true);
         assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"),   "omgnoway");
         assertEq(vm.envString("A_COMPLEX_ENV_VARIABLE"),        "y&2U9xiEINv!vM8Gez");
         assertEq(vm.envAddress("AN_ADDRESS"), 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
@@ -81,13 +84,16 @@ contract SolenvMergeTest is Test {
 }
 
 contract SolenvInSetupTest is Test {
+    bool private _success;
+
     function setUp() public {
         // act
-        Solenv.config();
+        _success = Solenv.config(".env.test");
     }
 
     function testEnv_InSetup() public {
         // assert
+        assertEq(_success, true);
         assertEq(vm.envString("WHY_USE_THIS_KEY"),              "because we can can can");
         assertEq(vm.envString("SOME_VERY_IMPORTANT_API_KEY"),   "omgnoway");
         assertEq(vm.envString("A_COMPLEX_ENV_VARIABLE"),        "y&2U9xiEINv!vM8Gez");


### PR DESCRIPTION
## Details

In general it is desirable to exercise the following heirachy:

```txt
CLI_ARGS > ENV_ARGS > FILE_ARGS
```

This change makes this possible via `Solenv.config(false)` which will not overwrite pre-existing environment variables.

Closes #3
